### PR TITLE
classesをリストの形で読み込むように変更した

### DIFF
--- a/src/lib/datasets/dataset/bbox_dataset.py
+++ b/src/lib/datasets/dataset/bbox_dataset.py
@@ -18,19 +18,14 @@ class BBOX_DATA(data.Dataset):
   std  = np.array([0.28863828, 0.27408164, 0.27809835],
                    dtype=np.float32).reshape(1, 1, 3)
 
-  def __init__(self, opt, classes_path, data_label_path, image_dir_path):
+  def __init__(self, opt, classes, data_label_path, image_dir_path):
     # super(COCO, self).__init__()
 
     self.max_objs = 128
     self.image_dir = image_dir_path
-    self.class_name = []
-    with open(classes_path, 'r') as f:
-      class_name = f.readline()
-      while class_name:
-        self.class_name.append(class_name.strip())
-        class_name = f.readline()
-  
-    self._valid_ids = list(range(len(class_name)))
+    self.class_name = classes
+
+    self._valid_ids = list(range(len(self.class_name)))
     self.cat_ids = {v: i for i, v in enumerate(self._valid_ids)}
 
     self.num_classes = len(self.class_name)


### PR DESCRIPTION
object_detectionのtrain_centernetでclasses.txtを読みこむように変更したため、それに合わせてclass情報をファイルパスからリストの形式で受け取るように変更しました。